### PR TITLE
bug with main_primitives

### DIFF
--- a/src/motion_primitives/motion_primitives.cpp
+++ b/src/motion_primitives/motion_primitives.cpp
@@ -413,6 +413,7 @@ void improve_motion_primitives(const Options_trajopt &options_trajopt,
     problem.start = traj.states.front();
     problem.robotType = dynamics;
     problem.models_base_path = options_primitives.models_base_path;
+    problem.robotTypes.resize(1);
 
     Result_opti opti_out;
 

--- a/src/motion_primitives/motion_primitives.cpp
+++ b/src/motion_primitives/motion_primitives.cpp
@@ -656,7 +656,7 @@ void generate_primitives(const Options_trajopt &options_trajopt,
     problem.goal = goal;
     problem.start = start;
     problem.robotType = options_primitives.dynamics;
-
+    problem.robotTypes.resize(1);
     // double try
 
     std::vector<double> try_rates{.5, 1., 2.};


### PR DESCRIPTION
Currently robot model (joint_robot or single) is decided by checking the size of the robotTypes vector. This vector remains empty unless the environment file is provided while creating the Problem problem. For motion primitive generation this environment file is not needed, that is why main_primitives can not be ran anymore with latest merged changes. 

I put the size of robotTypes vector manually since motion primitve generation is always done with single robot. 