### PR TITLE
add sequential low-level focal heuristic, pre-com

### DIFF
--- a/include/dynoplan/tdbastar/tdbastar_epsilon.hpp
+++ b/include/dynoplan/tdbastar/tdbastar_epsilon.hpp
@@ -78,7 +78,7 @@ int highLevelfocalHeuristicState(
     std::vector<fcl::CollisionObjectd *> &robot_objs);
 
 // computationally less efficient version of the low-level focal heuristic
-int lowLevelfocalHeuristicStatePrecise(
+int lowLevelfocalHeuristicSequential(
     std::vector<LowLevelPlan<dynobench::Trajectory>> &solution,
     Time_benchmark &time_bench,
     const std::vector<std::shared_ptr<dynobench::Model_robot>> &all_robots,

--- a/src/tdbastar/tdbastar_epsilon.cpp
+++ b/src/tdbastar/tdbastar_epsilon.cpp
@@ -177,9 +177,9 @@ int highLevelfocalHeuristicState(
   return numConflicts;
 }
 
-// state-based focal heuristic, doesn't work with car with trailer
-// for simplicity I assume robot_objs.size() = robot number. TO DO
-int lowLevelfocalHeuristicStatePrecise(
+// pair-wise checking. Doesn't support car with trailer because of
+// robot_objs.size = robots.size assumption
+int lowLevelfocalHeuristicSequential(
     std::vector<LowLevelPlan<dynobench::Trajectory>> &solution,
     Time_benchmark &time_bench,
     const std::vector<std::shared_ptr<dynobench::Model_robot>> &all_robots,
@@ -215,7 +215,8 @@ int lowLevelfocalHeuristicStatePrecise(
 
       all_robots[current_robot_idx]->transformation_collision_geometries(
           state1, tmp_ts1);
-      fcl::Transform3d &transform = tmp_ts1[0];
+
+      fcl::Transform3d &transform = tmp_ts1[0]; // no trailer
       robot_objs[current_robot_idx]->setTranslation(transform.translation());
       robot_objs[current_robot_idx]->setRotation(transform.rotation());
       robot_objs[current_robot_idx]->computeAABB();
@@ -230,7 +231,7 @@ int lowLevelfocalHeuristicStatePrecise(
           }
           all_robots[robot_idx]->transformation_collision_geometries(state2,
                                                                      tmp_ts2);
-          fcl::Transform3d &transform = tmp_ts2[0];
+          fcl::Transform3d &transform = tmp_ts2[0]; // no trailer
           robot_objs[robot_idx]->setTranslation(transform.translation());
           robot_objs[robot_idx]->setRotation(transform.rotation());
           robot_objs[robot_idx]->computeAABB();
@@ -859,15 +860,16 @@ void tdbastar_epsilon(
                                                   traj_wrapper.get_state(0));
       // it laso based on assumption that I am expanding from the version of the
       // best node with least/min focalHeuristic
+      focalHeuristic =
+          best_node_bestFocalHeuristic +
+          lowLevelfocalHeuristicSequential(
+              solution, time_bench, all_robots, traj_wrapper, robot_id,
+              best_node->gScore, robot_objs, reachesGoal);
       // focalHeuristic = best_node_bestFocalHeuristic +
-      //                  lowLevelfocalHeuristicStatePrecise(
-      //                      solution, all_robots, traj_wrapper, robot_id,
-      //                      best_node->gScore, robot_objs, reachesGoal);
-      focalHeuristic = best_node_bestFocalHeuristic +
-                       lowLevelfocalHeuristicState(
-                           solution, time_bench, all_robots, traj_wrapper,
-                           robot_id, best_node->gScore, col_mng_robots,
-                           robot_objs, reachesGoal, run_focal_heuristic);
+      //                  lowLevelfocalHeuristicState(
+      //                      solution, time_bench, all_robots, traj_wrapper,
+      //                      robot_id, best_node->gScore, col_mng_robots,
+      //                      robot_objs, reachesGoal, run_focal_heuristic);
 
       auto tmp_traj = dynobench::trajWrapper_2_Trajectory(traj_wrapper);
       tmp_traj.cost = best_node->gScore;


### PR DESCRIPTION
Sequential low-level focal heuristic is implemented. Benchmarked, and compared with 'all robot states per time at once' low-level focal heuristic. It is 2x faster starting from drone10c example, while the cost remain the same. 