### PR TITLE
add motion_to_motion function

### DIFF
--- a/include/dynoplan/ompl/robots.h
+++ b/include/dynoplan/ompl/robots.h
@@ -255,6 +255,10 @@ void traj_to_motion(const dynobench::Trajectory &traj,
                     dynobench::Model_robot &robot, Motion &motion_out,
                     bool compute_col);
 
+void motion_to_motion(std::vector<Motion> &robot_motions,
+                      std::vector<Motion> &motion_out,
+                      dynobench::Model_robot &robot, size_t N);
+
 void compute_col_shape(Motion &m, dynobench::Model_robot &robot);
 
 } // namespace dynoplan

--- a/include/dynoplan/tdbastar/tdbastar_epsilon.hpp
+++ b/include/dynoplan/tdbastar/tdbastar_epsilon.hpp
@@ -55,7 +55,6 @@ void tdbastar_epsilon(
     std::map<size_t, std::vector<size_t>> &robot_obj_sets, bool reverse_search,
     std::vector<dynobench::Trajectory> &expanded_trajs,
     std::vector<LowLevelPlan<dynobench::Trajectory>> &solution,
-    std::map<std::string, std::vector<Motion>> &robot_motions,
     const std::vector<std::shared_ptr<dynobench::Model_robot>> &all_robots,
     std::shared_ptr<fcl::BroadPhaseCollisionManagerd> col_mng_robots,
     std::vector<fcl::CollisionObjectd *> &robot_objs,

--- a/src/ompl/robots.cpp
+++ b/src/ompl/robots.cpp
@@ -3172,6 +3172,26 @@ void load_motion_primitives_new(const std::string &motionsFile,
     // motions[idx].last_state_translated = motions[idx].traj.states.back();
   }
 }
+// add N motions to motion_out. It starts adding from [current_size,....+N]
+void motion_to_motion(std::vector<Motion> &robot_motions,
+                      std::vector<Motion> &motion_out,
+                      dynobench::Model_robot &robot, size_t desired_size) {
+
+  std::cout << "before adding " << motion_out.size() << std::endl;
+  size_t N = std::min(desired_size, robot_motions.size());
+  for (size_t i = motion_out.size(); i < N; i++) {
+    dynoplan::Motion m;
+    m.traj = robot_motions.at(i).traj;
+    m.states.resize(m.traj.states.size());
+    m.actions.resize(m.traj.actions.size());
+    m.cost = m.traj.cost;
+    m.idx = motion_out.size();
+    compute_col_shape(m, robot);
+    motion_out.push_back(std::move(m));
+  }
+  // motion_out.shrink_to_fit();
+  std::cout << "after adding " << motion_out.size() << std::endl;
+}
 
 void traj_to_motion(const dynobench::Trajectory &traj,
                     dynobench::Model_robot &robot, Motion &motion_out,

--- a/src/tdbastar/tdbastar_epsilon.cpp
+++ b/src/tdbastar/tdbastar_epsilon.cpp
@@ -517,7 +517,6 @@ void tdbastar_epsilon(
     std::map<size_t, std::vector<size_t>> &robot_obj_sets, bool reverse_search,
     std::vector<dynobench::Trajectory> &expanded_trajs,
     std::vector<LowLevelPlan<dynobench::Trajectory>> &solution,
-    std::map<std::string, std::vector<Motion>> &robot_motions,
     const std::vector<std::shared_ptr<dynobench::Model_robot>> &all_robots,
     std::shared_ptr<fcl::BroadPhaseCollisionManagerd> col_mng_robots,
     std::vector<fcl::CollisionObjectd *> &robot_objs,


### PR DESCRIPTION
adding more motions. This function is added because .msgpack or .bin format motions are read only once. Checked with swap3 example from NeuralSwarm2 paper.