### PR TITLE
feat(dynoplan): add optimization stability costs and planner controls

### DIFF
--- a/include/dynoplan/optimization/croco_models.hpp
+++ b/include/dynoplan/optimization/croco_models.hpp
@@ -615,6 +615,40 @@ struct mujoco_quads_payload_acc : Cost {
   virtual ~mujoco_quads_payload_acc() = default;
 };
 
+// Softly align each cable direction (quad -> payload) with world down [0,0,-1].
+// Residual stacks 3D direction errors for each quad:
+//   r_i = k * ( normalize(p_payload - p_quad_i) - [0,0,-1] )
+// This discourages pathological formations where a quad goes below the payload.
+struct mujoco_quads_payload_cable_dir_cost : Cost {
+
+  std::shared_ptr<dynobench::Model_robot> model;
+  double k_dir = 1.0;
+  int num_bodies = 0;
+  int num_quads = 0;
+  int nq_pos = 0; // 7 * num_bodies (pose block length)
+
+  Eigen::Vector3d d_ref;
+  Eigen::VectorXd rbuf;
+  Eigen::MatrixXd Jx_res; // nr x nx (only pose position blocks nonzero)
+
+  mujoco_quads_payload_cable_dir_cost(
+      const std::shared_ptr<dynobench::Model_robot> &model_robot, double k_dir);
+
+  virtual void calc(Eigen::Ref<Eigen::VectorXd> r,
+                    const Eigen::Ref<const Eigen::VectorXd> &x,
+                    const Eigen::Ref<const Eigen::VectorXd> &u) override;
+
+  virtual void calcDiff(Eigen::Ref<Eigen::VectorXd> Lx,
+                        Eigen::Ref<Eigen::VectorXd> Lu,
+                        Eigen::Ref<Eigen::MatrixXd> Lxx,
+                        Eigen::Ref<Eigen::MatrixXd> Luu,
+                        Eigen::Ref<Eigen::MatrixXd> Lxu,
+                        const Eigen::Ref<const Eigen::VectorXd> &x,
+                        const Eigen::Ref<const Eigen::VectorXd> &u) override;
+
+  virtual ~mujoco_quads_payload_cable_dir_cost() = default;
+};
+
 
 struct Quad3d_acceleration_cost : Cost {
 

--- a/include/dynoplan/optimization/options.hpp
+++ b/include/dynoplan/optimization/options.hpp
@@ -59,6 +59,15 @@ struct Options_trajopt {
   bool use_cable_complementarity = true;
   double cable_complementarity_weight = 10.0;
 
+  // Optional overrides for MujocoQuadsPayload regularization (negative = keep model defaults)
+  double mujoco_payload_k_acc = -1.0;
+  double mujoco_payload_reg_w_quat = -1.0;
+  double mujoco_payload_reg_w_vel = -1.0;
+  double mujoco_payload_reg_w_ang_vel = -1.0;
+  double mujoco_payload_reg_w_payload_pos = -1.0;
+  double mujoco_payload_reg_w_quad_pos = -1.0;
+  double mujoco_payload_reg_w_cable_dir = -1.0;
+
   void add_options(po::options_description &desc);
 
   void __read_from_node(const YAML::Node &node);

--- a/include/dynoplan/tdbastar/options.hpp
+++ b/include/dynoplan/tdbastar/options.hpp
@@ -61,6 +61,8 @@ struct Options_tdbastar {
   bool check_cols = true;
   bool rewire = true; // to allow rewiring during the search
   bool shuffle = false; // shuffle motions when loading
+  bool collect_expanded_trajs =
+      true; // store full expanded trajectories in expanded_trajs output vector
 
   void add_options(po::options_description &desc);
 

--- a/src/ompl/robots.cpp
+++ b/src/ompl/robots.cpp
@@ -3110,7 +3110,7 @@ void load_motion_primitives_new(const std::string &motionsFile,
 
   motions.resize(trajs.data.size());
 
-  bool add_noise_first_state = true;
+  bool add_noise_first_state = false;
   CSTR_(add_noise_first_state);
 
   if (add_noise_first_state) {

--- a/src/optimization/croco_models.cpp
+++ b/src/optimization/croco_models.cpp
@@ -1690,6 +1690,87 @@ void mujoco_quads_payload_acc::calcDiff(
 }
 
 //////////////////////////////////
+
+mujoco_quads_payload_cable_dir_cost::mujoco_quads_payload_cable_dir_cost(
+    const std::shared_ptr<dynobench::Model_robot> &model_robot, double k_dir)
+    : Cost(model_robot->nx, model_robot->nu, 3 * (int(model_robot->nx / 13) - 1)),
+      model(model_robot), k_dir(k_dir) {
+
+  name = "mujoco_quads_payload_cable_dir";
+  num_bodies = int(model_robot->nx / 13);
+  num_quads = num_bodies - 1;
+  nq_pos = 7 * num_bodies;
+  d_ref << 0., 0., -1.;
+  rbuf.resize(nr);
+  rbuf.setZero();
+  Jx_res.resize(nr, nx);
+  Jx_res.setZero();
+}
+
+void mujoco_quads_payload_cable_dir_cost::calc(
+    Eigen::Ref<Eigen::VectorXd> r, const Eigen::Ref<const Eigen::VectorXd> &x,
+    const Eigen::Ref<const Eigen::VectorXd> &u) {
+  (void)u;
+  check_input_calc(r, x, u);
+  DYNO_CHECK_GE(num_quads, 1, AT);
+
+  const auto poses = x.head(nq_pos);
+  const Eigen::Vector3d p_payload = poses.segment<3>(0);
+  const double eps = 1e-9;
+  for (int qi = 0; qi < num_quads; ++qi) {
+    const int base = 7 * (1 + qi);
+    const Eigen::Vector3d p_quad = poses.segment<3>(base);
+    const Eigen::Vector3d rel = p_payload - p_quad; // quad -> payload vector
+    const double L = std::max(rel.norm(), eps);
+    const Eigen::Vector3d d = rel / L;
+    r.segment<3>(3 * qi) = k_dir * (d - d_ref);
+  }
+}
+
+void mujoco_quads_payload_cable_dir_cost::calcDiff(
+    Eigen::Ref<Eigen::VectorXd> Lx, Eigen::Ref<Eigen::VectorXd> Lu,
+    Eigen::Ref<Eigen::MatrixXd> Lxx, Eigen::Ref<Eigen::MatrixXd> Luu,
+    Eigen::Ref<Eigen::MatrixXd> Lxu, const Eigen::Ref<const Eigen::VectorXd> &x,
+    const Eigen::Ref<const Eigen::VectorXd> &u) {
+
+  (void)Luu;
+  (void)Lxu;
+  check_input_calcDiff(Lx, Lu, Lxx, Luu, Lxu, x, u);
+  DYNO_CHECK_GE(num_quads, 1, AT);
+
+  Jx_res.setZero();
+  rbuf.setZero();
+
+  const auto poses = x.head(nq_pos);
+  const Eigen::Vector3d p_payload = poses.segment<3>(0);
+  const double eps = 1e-9;
+  const Eigen::Matrix3d I = Eigen::Matrix3d::Identity();
+
+  for (int qi = 0; qi < num_quads; ++qi) {
+    const int qbase = 7 * (1 + qi);
+    const Eigen::Vector3d p_quad = poses.segment<3>(qbase);
+    const Eigen::Vector3d rel = p_payload - p_quad; // quad -> payload
+    const double L = std::max(rel.norm(), eps);
+    const Eigen::Vector3d d = rel / L;
+
+    rbuf.segment<3>(3 * qi) = k_dir * (d - d_ref);
+
+    // d(normalize(rel))/drel = I/L - rel*rel^T / L^3
+    const Eigen::Matrix3d Jdir_rel =
+        (I / L) - (rel * rel.transpose()) / (L * L * L);
+    const Eigen::Matrix3d Jblock = k_dir * Jdir_rel;
+
+    // rel = p_payload - p_quad
+    Jx_res.block<3, 3>(3 * qi, 0) += Jblock;
+    Jx_res.block<3, 3>(3 * qi, qbase) += -Jblock;
+  }
+
+  // Least-squares residual cost: 0.5 * ||r||^2
+  Lx.head(nx) += Jx_res.transpose() * rbuf;
+  Lxx.block(0, 0, nx, nx) += Jx_res.transpose() * Jx_res; // Gauss-Newton
+}
+
+//////////////////////////////////
 void Payload_n_acceleration_cost::calc(
     Eigen::Ref<Eigen::VectorXd> r, const Eigen::Ref<const Eigen::VectorXd> &x,
     const Eigen::Ref<const Eigen::VectorXd> &u) {

--- a/src/optimization/generate_ocp.cpp
+++ b/src/optimization/generate_ocp.cpp
@@ -92,6 +92,7 @@ generate_problem(const Generate_params &gen_args,
 
   bool use_hard_bounds = options_trajopt.control_bounds;
 
+    ptr<Cost> start_cost_feature = mk<State_cost_model>(gen_args.model_robot, nx, nu, options_trajopt.weight_goal * gen_args.model_robot->goal_weight, gen_args.start);
   if (options_trajopt.soft_control_bounds) {
     use_hard_bounds = false;
   }
@@ -99,10 +100,15 @@ generate_problem(const Generate_params &gen_args,
   // CHECK(
   //     !(options_trajopt.control_bounds &&
   //     options_trajopt.soft_control_bounds), AT);
-  Vxd control_ref = Vxd::Zero(nu);
+  Vxd control_ref = Vxd::Ones(nu);
+  bool payload_reg_overrides_applied = false;
   for (size_t t = 0; t < gen_args.N; t++) {
 
     std::vector<ptr<Cost>> feats_run;
+
+    if (t == 0) {
+      feats_run.push_back(start_cost_feature);
+    }
     if (gen_args.reg_control) {
       if (t < ref_traj.actions.size()) {
         if (t < 5) std::cout << "adding regularization for control! " << std::endl;
@@ -113,16 +119,20 @@ generate_problem(const Generate_params &gen_args,
       }
 
       // Vxd state_weights = Vxd::Constant(nx, 0.0);
-      // state_weights.segment(0, 3).setConstant(10.0); // only payload pos
+      // int n_bodies = (int) nx / 13;
+      // for (int i=0; i < n_bodies; i++) {
+      //   state_weights.segment(i*7, 3).setConstant(500.0); // payload pos
+      // }
+      // // state_weights.segment(0, 3).setConstant(100.0); // only payload pos
       // Vxd state_ref = Vxd::Zero(nx);
       // state_ref     = ref_traj.states.at(t);
       // ptr<Cost> state_track_feature = mk<State_cost>(
-      //   nx, nu, nx, state_weights, state_ref);
+      //   nx, nu, nx, state_weights, gen_args.goal);
       //   feats_run.push_back(state_track_feature);
     }
 
 
-    if (gen_args.collisions && gen_args.model_robot->env) {
+    if (gen_args.collisions) {
       ptr<Cost> cl_feature = mk<Col_cost>(nx, nu, 1, gen_args.model_robot,
                                           options_trajopt.collision_weight);
       feats_run.push_back(cl_feature);
@@ -214,13 +224,73 @@ generate_problem(const Generate_params &gen_args,
     // exit(3);
     // COSTS FOR MUJOCO QUADROTOR PAYLOAD
     if (startsWith(gen_args.name, "mujocoquadspayload")) {
+      auto ptr_derived =
+          std::dynamic_pointer_cast<dynobench::Model_MujocoQuadsPayload>(
+              gen_args.model_robot);
+      if (ptr_derived && !payload_reg_overrides_applied) {
+        const bool has_any_override =
+            options_trajopt.mujoco_payload_k_acc >= 0.0 ||
+            options_trajopt.mujoco_payload_reg_w_quat >= 0.0 ||
+            options_trajopt.mujoco_payload_reg_w_vel >= 0.0 ||
+            options_trajopt.mujoco_payload_reg_w_ang_vel >= 0.0 ||
+            options_trajopt.mujoco_payload_reg_w_payload_pos >= 0.0 ||
+            options_trajopt.mujoco_payload_reg_w_quad_pos >= 0.0 ||
+            options_trajopt.mujoco_payload_reg_w_cable_dir >= 0.0;
+        if (has_any_override) {
+          const std::size_t nq = ptr_derived->params.num_robots;
+          const std::size_t nb = 1 + nq;
+          const std::size_t qpos_dim = 7 * nb;
+          const std::size_t qvel_start = qpos_dim;
+          if (options_trajopt.mujoco_payload_k_acc >= 0.0) {
+            ptr_derived->k_acc = options_trajopt.mujoco_payload_k_acc;
+          }
+          if (ptr_derived->state_weights.size() == ptr_derived->nx &&
+              ptr_derived->state_ref.size() == ptr_derived->nx) {
+            if (options_trajopt.mujoco_payload_reg_w_payload_pos >= 0.0) {
+              ptr_derived->state_weights.segment<3>(0).setConstant(
+                  options_trajopt.mujoco_payload_reg_w_payload_pos);
+            }
+            if (options_trajopt.mujoco_payload_reg_w_vel >= 0.0) {
+              ptr_derived->state_weights.segment<3>(qvel_start).setConstant(
+                  options_trajopt.mujoco_payload_reg_w_vel);
+            }
+            for (std::size_t i = 0; i < nq; ++i) {
+              const std::size_t body_idx = 1 + i;
+              const std::size_t qpos_base = 7 * body_idx;
+              const std::size_t qvel_base = qvel_start + 6 * body_idx;
+              if (options_trajopt.mujoco_payload_reg_w_quad_pos >= 0.0) {
+                ptr_derived->state_weights.segment<3>(qpos_base).setConstant(
+                    options_trajopt.mujoco_payload_reg_w_quad_pos);
+              }
+              if (options_trajopt.mujoco_payload_reg_w_quat >= 0.0) {
+                ptr_derived->state_weights.segment<4>(qpos_base + 3).setConstant(
+                    options_trajopt.mujoco_payload_reg_w_quat);
+              }
+              if (options_trajopt.mujoco_payload_reg_w_vel >= 0.0) {
+                ptr_derived->state_weights.segment<3>(qvel_base).setConstant(
+                    options_trajopt.mujoco_payload_reg_w_vel);
+              }
+              if (options_trajopt.mujoco_payload_reg_w_ang_vel >= 0.0) {
+                ptr_derived->state_weights.segment<3>(qvel_base + 3).setConstant(
+                    options_trajopt.mujoco_payload_reg_w_ang_vel);
+              }
+            }
+          }
+          std::cout << "[trajopt] applied mujocoquadspayload overrides: "
+                    << "k_acc=" << ptr_derived->k_acc
+                    << " w_quat=" << options_trajopt.mujoco_payload_reg_w_quat
+                    << " w_vel=" << options_trajopt.mujoco_payload_reg_w_vel
+                    << " w_ang_vel=" << options_trajopt.mujoco_payload_reg_w_ang_vel
+                    << " w_payload_pos=" << options_trajopt.mujoco_payload_reg_w_payload_pos
+                    << " w_quad_pos=" << options_trajopt.mujoco_payload_reg_w_quad_pos
+                    << " w_cable_dir=" << options_trajopt.mujoco_payload_reg_w_cable_dir
+                    << std::endl;
+        }
+        payload_reg_overrides_applied = true;
+      }
       if (control_mode == Control_Mode::free_time) {
         // std::cout << "adding regularization on the acceleration! " << std::endl;
 
-        auto ptr_derived =
-            std::dynamic_pointer_cast<dynobench::Model_MujocoQuadsPayload>(
-                gen_args.model_robot);
-        
         if (gen_args.regularize_state) {
           ptr<Cost> state_feature = mk<State_cost>(
               nx, nu, nx, ptr_derived->state_weights, ptr_derived->state_ref);
@@ -229,17 +299,26 @@ generate_problem(const Generate_params &gen_args,
         ptr<Cost> acc_cost = mk<mujoco_quads_payload_acc>(
             gen_args.model_robot, gen_args.model_robot->k_acc);
         feats_run.push_back(acc_cost);
+        if (options_trajopt.mujoco_payload_reg_w_cable_dir > 0.0) {
+          ptr<Cost> cable_dir_feature = mk<mujoco_quads_payload_cable_dir_cost>(
+              gen_args.model_robot, options_trajopt.mujoco_payload_reg_w_cable_dir);
+          feats_run.push_back(cable_dir_feature);
+        }
       }
 
       if (control_mode == Control_Mode::default_mode && gen_args.regularize_state) {
         if (t < 5) std::cout << "adding regularization on the acceleration and state! " << std::endl;
-        auto ptr_derived = std::dynamic_pointer_cast<dynobench::Model_MujocoQuadsPayload>(gen_args.model_robot);
 
         ptr<Cost> state_reg_feature = mk<State_cost>(nx, nu, nx, ptr_derived->state_weights, ptr_derived->state_ref);
         feats_run.push_back(state_reg_feature);
 
         ptr<Cost> acc_feature = mk<mujoco_quads_payload_acc>(gen_args.model_robot, gen_args.model_robot->k_acc);
         feats_run.push_back(acc_feature);
+        if (options_trajopt.mujoco_payload_reg_w_cable_dir > 0.0) {
+          ptr<Cost> cable_dir_feature = mk<mujoco_quads_payload_cable_dir_cost>(
+              gen_args.model_robot, options_trajopt.mujoco_payload_reg_w_cable_dir);
+          feats_run.push_back(cable_dir_feature);
+        }
       }
     
     }
@@ -312,6 +391,7 @@ generate_problem(const Generate_params &gen_args,
         gen_args.penalty * options_trajopt.weight_goal * goal_weight,
         // Vxd::Ones(gen_args.model_robot->nx),
         gen_args.goal);
+    
 
     feats_terminal.push_back(goal_feature);
   }

--- a/src/optimization/opt_simulate_mujoco.cpp
+++ b/src/optimization/opt_simulate_mujoco.cpp
@@ -480,19 +480,19 @@ bool execute_optILMujoco(std::string &env_file,
     dynobench::Trajectory init_guess;
     init_guess.read_from_yaml(init_file.c_str());
 
-    while (init_guess.states.size() < N_opt + 1) {
-        init_guess.states.push_back(init_guess.states.back());
-    }
-    if (init_guess.states.size() > N_opt + 1) {
-        init_guess.states.resize(N_opt + 1);
-    }
+    // while (init_guess.states.size() < N_opt + 1) {
+    //     init_guess.states.push_back(init_guess.states.back());
+    // }
+    // if (init_guess.states.size() > N_opt + 1) {
+    //     init_guess.states.resize(N_opt + 1);
+    // }
 
-    while (init_guess.actions.size() < N_opt) {
-        init_guess.actions.push_back(init_guess.actions.back());
-    }
-    if (init_guess.actions.size() > N_opt) {
-        init_guess.actions.resize(N_opt);
-    }
+    // while (init_guess.actions.size() < N_opt) {
+    //     init_guess.actions.push_back(init_guess.actions.back());
+    // }
+    // if (init_guess.actions.size() > N_opt) {
+    //     init_guess.actions.resize(N_opt);
+    // }
 
     std::cout << "optimizing trajectory..." << std::endl;
     optimize_N_steps(problem, init_guess, options_trajopt, sol, result);
@@ -506,8 +506,8 @@ bool execute_optILMujoco(std::string &env_file,
     } else {
         std::cout << "Optimization failed. Falling back to first 2 steps." << std::endl;
 
-        // ---- fallback: keep first 2 steps (2 actions, 3 states) if available ----
-        const size_t K = 2;
+        // ---- fallback: keep first 2 steps (1 actions, 2 states) if available ----
+        const size_t K = 1;
 
         if (result.xs_out.size() >= K + 1 && result.us_out.size() >= K) {
             sol.states.assign(result.xs_out.begin(), result.xs_out.begin() + (K + 1));

--- a/src/optimization/options.cpp
+++ b/src/optimization/options.cpp
@@ -45,6 +45,13 @@ void Options_trajopt::add_options(po::options_description &desc) {
   set_from_boostop(desc, VAR_WITH_NAME(linear_search));
   set_from_boostop(desc, VAR_WITH_NAME(reg_control));
   set_from_boostop(desc, VAR_WITH_NAME(penalty_iterations));
+  set_from_boostop(desc, VAR_WITH_NAME(mujoco_payload_k_acc));
+  set_from_boostop(desc, VAR_WITH_NAME(mujoco_payload_reg_w_quat));
+  set_from_boostop(desc, VAR_WITH_NAME(mujoco_payload_reg_w_vel));
+  set_from_boostop(desc, VAR_WITH_NAME(mujoco_payload_reg_w_ang_vel));
+  set_from_boostop(desc, VAR_WITH_NAME(mujoco_payload_reg_w_payload_pos));
+  set_from_boostop(desc, VAR_WITH_NAME(mujoco_payload_reg_w_quad_pos));
+  set_from_boostop(desc, VAR_WITH_NAME(mujoco_payload_reg_w_cable_dir));
 
 }
 
@@ -95,6 +102,13 @@ void Options_trajopt::__read_from_node(const YAML::Node &node) {
   set_from_yaml(node, VAR_WITH_NAME(linear_search));
   set_from_yaml(node, VAR_WITH_NAME(reg_control));
   set_from_yaml(node, VAR_WITH_NAME(penalty_iterations));
+  set_from_yaml(node, VAR_WITH_NAME(mujoco_payload_k_acc));
+  set_from_yaml(node, VAR_WITH_NAME(mujoco_payload_reg_w_quat));
+  set_from_yaml(node, VAR_WITH_NAME(mujoco_payload_reg_w_vel));
+  set_from_yaml(node, VAR_WITH_NAME(mujoco_payload_reg_w_ang_vel));
+  set_from_yaml(node, VAR_WITH_NAME(mujoco_payload_reg_w_payload_pos));
+  set_from_yaml(node, VAR_WITH_NAME(mujoco_payload_reg_w_quad_pos));
+  set_from_yaml(node, VAR_WITH_NAME(mujoco_payload_reg_w_cable_dir));
 }
 
 void Options_trajopt::read_from_yaml(YAML::Node &node) {
@@ -151,6 +165,13 @@ void Options_trajopt::print(std::ostream &out, const std::string &be,
   out << be << STR(linear_search, af) << std::endl;
   out << be << STR(reg_control, af) << std::endl;
   out << be << STR(penalty_iterations, af) << std::endl;
+  out << be << STR(mujoco_payload_k_acc, af) << std::endl;
+  out << be << STR(mujoco_payload_reg_w_quat, af) << std::endl;
+  out << be << STR(mujoco_payload_reg_w_vel, af) << std::endl;
+  out << be << STR(mujoco_payload_reg_w_ang_vel, af) << std::endl;
+  out << be << STR(mujoco_payload_reg_w_payload_pos, af) << std::endl;
+  out << be << STR(mujoco_payload_reg_w_quad_pos, af) << std::endl;
+  out << be << STR(mujoco_payload_reg_w_cable_dir, af) << std::endl;
 }
 
 void PrintVariableMap(const boost::program_options::variables_map &vm,

--- a/src/tdbastar/tdbastar.cpp
+++ b/src/tdbastar/tdbastar.cpp
@@ -11,6 +11,7 @@
 // #include <boost/functional/hash.hpp>
 #include <boost/heap/d_ary_heap.hpp>
 #include <boost/program_options.hpp>
+#include <cstdlib>
 
 // OMPL headers
 #include <ompl/base/spaces/RealVectorStateSpace.h>
@@ -581,6 +582,13 @@ void tdbastar(
   // else {
   //   NOT_IMPLEMENTED;
   // }
+  std::unique_ptr<ompl::NearestNeighbors<Motion *>> T_m_owner(T_m);
+  std::unique_ptr<ompl::NearestNeighbors<std::shared_ptr<AStarNode>>> T_n_owner(
+      T_n);
+  if (heuristic_result) {
+    // Caller owns the heuristic NN pointer when requested (reverse search).
+    T_n_owner.release();
+  }
 
   time_bench.time_nearestMotion += timed_fun_void([&] {
     for (size_t i = 0;
@@ -591,6 +599,10 @@ void tdbastar(
 
   Expander expander(robot.get(), T_m,
                     options_tdbastar.alpha * options_tdbastar.delta);
+  if (options_tdbastar.fix_seed) {
+    // Deterministic mode: keep NN neighbor order stable instead of shuffling.
+    expander.random = false;
+  }
   if (options_tdbastar.alpha <= 0 || options_tdbastar.alpha >= 1) {
     ERROR_WITH_INFO("Alpha needs to be between 0 and 1!");
   }
@@ -641,6 +653,7 @@ void tdbastar(
   }
   open_t open;
   start_node->handle = open.push(start_node);
+  size_t open_peak_size = open.size();
 
   Motion fakeMotion;
   fakeMotion.idx = -1;
@@ -677,6 +690,7 @@ void tdbastar(
 
   Stopwatch watch;
   Terminate_status status = Terminate_status::UNKNOWN;
+  size_t expanded_count = 0;
 
   auto stop_search = [&] {
     if (static_cast<size_t>(time_bench.expands) >=
@@ -831,9 +845,12 @@ void tdbastar(
       if (gScore > upper_bound) {
         continue;
       }
-      auto tmp_traj = dynobench::trajWrapper_2_Trajectory(traj_wrapper);
-      tmp_traj.cost = best_node->gScore;
-      expanded_trajs.push_back(tmp_traj);
+      ++expanded_count;
+      if (options_tdbastar.collect_expanded_trajs) {
+        auto tmp_traj = dynobench::trajWrapper_2_Trajectory(traj_wrapper);
+        tmp_traj.cost = best_node->gScore;
+        expanded_trajs.push_back(std::move(tmp_traj));
+      }
       // CHECK if new State is NOVEL
       time_bench.time_nearestNode_search += timed_fun_void([&] {
         T_n->nearestR(tmp_node,
@@ -861,6 +878,7 @@ void tdbastar(
         __node->current_arrival_idx = 0;
         time_bench.time_queue +=
             timed_fun_void([&] { __node->handle = open.push(__node); });
+        open_peak_size = std::max(open_peak_size, open.size());
         time_bench.time_nearestNode_add +=
             timed_fun_void([&] { T_n->add(__node); });
 
@@ -905,6 +923,7 @@ void tdbastar(
                   n->is_in_open = true;
                   time_bench.time_queue +=
                       timed_fun_void([&] { n->handle = open.push(n); });
+                  open_peak_size = std::max(open_peak_size, open.size());
                 }
               }
             }
@@ -1013,6 +1032,28 @@ void tdbastar(
       std::make_pair("delta", std::to_string(options_tdbastar.delta)));
   out_info_tdb.data.insert(
       std::make_pair("num_primitives", std::to_string(motions.size())));
+  size_t arrivals_total = 0;
+  size_t arrivals_max_per_node = 0;
+  for (const auto &n : all_nodes) {
+    arrivals_total += n->arrivals.size();
+    arrivals_max_per_node = std::max(arrivals_max_per_node, n->arrivals.size());
+  }
+  out_info_tdb.data.insert(
+      std::make_pair("expanded_count", std::to_string(expanded_count)));
+  out_info_tdb.data.insert(
+      std::make_pair("all_nodes_count", std::to_string(all_nodes.size())));
+  out_info_tdb.data.insert(
+      std::make_pair("nn_nodes_count", std::to_string(T_n ? T_n->size() : 0)));
+  out_info_tdb.data.insert(
+      std::make_pair("expands_count", std::to_string(time_bench.expands)));
+  out_info_tdb.data.insert(
+      std::make_pair("open_peak_size", std::to_string(open_peak_size)));
+  out_info_tdb.data.insert(
+      std::make_pair("open_final_size", std::to_string(open.size())));
+  out_info_tdb.data.insert(
+      std::make_pair("arrivals_total", std::to_string(arrivals_total)));
+  out_info_tdb.data.insert(std::make_pair(
+      "arrivals_max_per_node", std::to_string(arrivals_max_per_node)));
 }
 
 } // namespace dynoplan


### PR DESCRIPTION
## Summary
Adds optimization stability/control terms and planner option updates for payload planning, and updates dynobench pointer to include prerequisite model changes.

## Changes
### Optimization stack
- `src/optimization/generate_ocp.cpp`
- `src/optimization/croco_models.cpp`
- `include/dynoplan/optimization/croco_models.hpp`
- `src/optimization/options.cpp`
- `include/dynoplan/optimization/options.hpp`
- `src/optimization/opt_simulate_mujoco.cpp`

### Planner/search controls
- `src/tdbastar/tdbastar.cpp`
- `include/dynoplan/tdbastar/options.hpp`
- `src/ompl/robots.cpp`

### Submodule update
- bumps `dynobench` submodule pointer

## Why
Needed better optimization behavior and explicit controls used by deterministic payload runs and DAgger expert generation.

## Validation
- Compiled and used in downstream pc-dbCBS integration flow.
- Checked behavior with payload planning/evaluation scripts.

## Notes
- Depends on merged dynobench PR.
- Must merge before pc-dbCBS PR.
